### PR TITLE
Changes to add Lambda Stack with Iam Role

### DIFF
--- a/infrastructure/bin/main.ts
+++ b/infrastructure/bin/main.ts
@@ -1,9 +1,11 @@
 #!/usr/local/opt/node/bin/node
 import * as cdk from 'aws-cdk-lib';
 import { RoleStack } from '../lib/iam';
+import { LambdaStack } from '../lib/lambda';
+import { Code, Runtime } from 'aws-cdk-lib/aws-lambda';
 
 const app = new cdk.App();
-new RoleStack(app, 'role', {
+const roleStackObj = new RoleStack(app, 'role', {
   env: {
     account: '123456789012', // dummy AWS account ID
     region: 'us-east-1',
@@ -13,3 +15,11 @@ new RoleStack(app, 'role', {
   servicePrincipal: 'ecs-tasks.amazonaws.com',
   policyActions: ['s3:ListBucket', 's3:GetObject'],
 });
+
+
+
+new LambdaStack(app, "test",
+   {lambdaRole: roleStackObj.role,
+    runtime: Runtime.NODEJS_20_X,
+    code: Code.fromAsset('../lambda'),
+    handler: 'hello.handler'});

--- a/infrastructure/lib/iam.ts
+++ b/infrastructure/lib/iam.ts
@@ -25,13 +25,14 @@ function createRole(scope: Construct, id: string, props: IamProps) {
 }
 
 export class RoleStack extends cdk.Stack {
+  public readonly role: Role;
   constructor(scope: Construct, id: string, props: IamProps) {
     super(scope, id, props);
 
-    const role = createRole(this, id, props);
+    this.role = createRole(this, id, props);
 
     new CfnOutput(this, 'RoleArn', {
-      value: role.roleArn,
+      value: this.role.roleArn,
       description: 'The ARN of the IAM role',
       exportName: 'RoleArn',
     });

--- a/infrastructure/lib/lambda.ts
+++ b/infrastructure/lib/lambda.ts
@@ -1,0 +1,21 @@
+import { Construct } from 'constructs';
+import { Stack } from 'aws-cdk-lib';
+import { LambdaStackProps } from './props/lambda-props';
+import { Runtime, Code, Function } from 'aws-cdk-lib/aws-lambda';
+
+// Reference on Logic in Tutorial here:
+// https://docs.aws.amazon.com/cdk/v2/guide/serverless-example.html
+
+export class LambdaStack extends Stack{
+    constructor(scope: Construct, id: string, props: LambdaStackProps){
+        super(scope, id, props);
+        // Ref: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda-readme.html
+        // Define the Lambda function resource
+        const helloWorldFunction = new Function(this, 'HelloWorldFunction', {
+            runtime: Runtime.NODEJS_20_X, // Choose any supported Node.js runtime
+            code: Code.fromAsset('../lambda'), // Points to the lambda directory
+            handler: 'hello.handler', // Points to the 'hello' file in the lambda directory
+            role: props.lambdaRole ? props.lambdaRole : undefined
+        });
+    }
+}

--- a/infrastructure/lib/props/iam-props.ts
+++ b/infrastructure/lib/props/iam-props.ts
@@ -1,6 +1,7 @@
 import { StackProps } from "aws-cdk-lib";
 
 export interface IamProps extends StackProps {
+    readonly env: {[key: string]: string };
     readonly roleName: string;
     readonly description: string;
     readonly servicePrincipal: string;

--- a/infrastructure/lib/props/lambda-props.ts
+++ b/infrastructure/lib/props/lambda-props.ts
@@ -1,0 +1,14 @@
+import { StackProps } from "aws-cdk-lib";
+import { Role } from 'aws-cdk-lib/aws-iam';
+import { Code } from 'aws-cdk-lib/aws-lambda';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+
+
+// Reference: https://constructs.dev/packages/@aws-cdk/aws-lambda/v/1.204.0?lang=typescript
+export interface LambdaStackProps extends StackProps {
+    lambdaRole ?: Role;
+    handler: string;
+    code: Code;
+    runtime: Runtime;
+}
+

--- a/infrastructure/test/infrastructure.test.ts
+++ b/infrastructure/test/infrastructure.test.ts
@@ -1,17 +1,72 @@
-// import * as cdk from 'aws-cdk-lib';
-// import { Template } from 'aws-cdk-lib/assertions';
-// import * as Infrastructure from '../lib/infrastructure-stack';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as lambda from '../lib/lambda';
+import * as iam from '../lib/iam';
+
+import { Code, Runtime } from 'aws-cdk-lib/aws-lambda';
 
 // example test. To run these tests, uncomment this file along with the
 // example resource in lib/infrastructure-stack.ts
-test('SQS Queue Created', () => {
-//   const app = new cdk.App();
-//     // WHEN
-//   const stack = new Infrastructure.InfrastructureStack(app, 'MyTestStack');
-//     // THEN
-//   const template = Template.fromStack(stack);
+test('Lambda Function Created No Role', () => {
+  const app = new cdk.App();
+  const stack = new lambda.LambdaStack(app, 'MyTestStack',
+        { runtime: Runtime.NODEJS_20_X,
+        code: Code.fromAsset('../lambda'),
+        handler: 'hello.handler'}
+    );
 
-//   template.hasResourceProperties('AWS::SQS::Queue', {
-//     VisibilityTimeout: 300
-//   });
+    const template = Template.fromStack(stack);
+
+    // Assert it creates the function with the correct properties...
+    template.hasResourceProperties("AWS::Lambda::Function", {
+        Handler: "hello.handler",
+        Runtime: "nodejs20.x",
+        });
+
 });
+
+test('Lambda Function Created Has Role', () => {
+    const app = new cdk.App();
+    const iamStack = new iam.RoleStack(app, 'MyTestStackIam', {
+        env: {
+            account: '123456789012', // dummy AWS account ID
+            region: 'us-east-1',
+          },
+          roleName: 'MyRole',
+          description: 'My role description',
+          servicePrincipal: 'ecs-tasks.amazonaws.com',
+          policyActions: ['s3:ListBucket', 's3:GetObject'],
+    })
+    const lambdaStack = new lambda.LambdaStack(app, 'MyTestStackLambda',
+        {lambdaRole: iamStack.role,
+          runtime: Runtime.NODEJS_20_X,
+          code: Code.fromAsset('../lambda'),
+          handler: 'hello.handler'}
+    );
+
+
+
+    // console.log(iamStack.role)
+
+    const template = Template.fromStack(lambdaStack)
+    console.log(JSON.stringify(template.toJSON(), null, 2));
+
+    template.hasResourceProperties("AWS::Lambda::Function", {
+        Handler: "hello.handler",
+        Runtime: "nodejs20.x",
+        
+        // Not sure if this is the best waty to test this
+        Role: {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                { Ref: "AWS::Partition" },
+                ":iam::123456789012:role/MyRole"
+              ]
+            ]
+          }
+        });
+
+  });
+  

--- a/lambda/hello.js
+++ b/lambda/hello.js
@@ -1,0 +1,7 @@
+exports.handler = async (event) => {
+    return {
+        statusCode: 200,
+        headers: { "Content-Type": "text/plain" },
+        body: JSON.stringify({ message: "Hello, World!" }),
+    };
+};


### PR DESCRIPTION

CDK Snyth Test Output:
`cBookPro:infrastructure neilbhavsar$ cdk synth test
Resources:
  HelloWorldFunctionB2AB6E79:
    Type: AWS::Lambda::Function
    Properties:
      Code:
        S3Bucket:
          Fn::Sub: cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}
        S3Key: <Scrubbed>
      Handler: hello.handler
      Role: arn:aws:iam::123456789012:role/MyRole
      Runtime: nodejs20.x
    Metadata:
      aws:cdk:path: test/HelloWorldFunction/Resource
      aws:asset:path: asset.fe7e1908d59e783c3f2793117673f2e93c85f0ce91cd99bed0239de3d41e8d3b
      aws:asset:is-bundled: false
      aws:asset:property: Code
  CDKMetadata:
    Type: AWS::CDK::Metadata
    Properties:
      Analytics: v2:<Scrubbed>
    Metadata:
      aws:cdk:path: test/CDKMetadata/Default
    Condition: CDKMetadataAvailable
Conditions:
  CDKMetadataAvailable:
    Fn::Or:
      - Fn::Or:
          - Fn::Equals:
              - Ref: AWS::Region
              - af-south-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-east-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-northeast-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-northeast-2
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-northeast-3
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-south-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-south-2
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-southeast-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-southeast-2
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-southeast-3
      - Fn::Or:
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-southeast-4
          - Fn::Equals:
              - Ref: AWS::Region
              - ca-central-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ca-west-1
          - Fn::Equals:
              - Ref: AWS::Region
              - cn-north-1
          - Fn::Equals:
              - Ref: AWS::Region
              - cn-northwest-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-central-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-central-2
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-north-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-south-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-south-2
      - Fn::Or:
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-west-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-west-2
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-west-3
          - Fn::Equals:
              - Ref: AWS::Region
              - il-central-1
          - Fn::Equals:
              - Ref: AWS::Region
              - me-central-1
          - Fn::Equals:
              - Ref: AWS::Region
              - me-south-1
          - Fn::Equals:
              - Ref: AWS::Region
              - sa-east-1
          - Fn::Equals:
              - Ref: AWS::Region
              - us-east-1
          - Fn::Equals:
              - Ref: AWS::Region
              - us-east-2
          - Fn::Equals:
              - Ref: AWS::Region
              - us-west-1
      - Fn::Equals:
          - Ref: AWS::Region
          - us-west-2
Parameters:
  BootstrapVersion:
    Type: AWS::SSM::Parameter::Value<String>
    Default: /cdk-bootstrap/hnb659fds/version
    Description: Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]`


NPM Test:


 PASS  test/infrastructure.test.ts (14.951 s)
  ✓ Lambda Function Created No Role (638 ms)
  ✓ Lambda Function Created Has Role (84 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        15.353 s, estimated 17 s
Ran all test suites.